### PR TITLE
[wip] Alternative API: allow to access DB explicitly

### DIFF
--- a/scrapy_crawl_once/__init__.py
+++ b/scrapy_crawl_once/__init__.py
@@ -1,3 +1,4 @@
 # -*- coding: utf-8 -*-
 __version__ = '0.1.1'
 from .middlewares import CrawlOnceMiddleware
+from .db import CrawlOnceDB

--- a/scrapy_crawl_once/db.py
+++ b/scrapy_crawl_once/db.py
@@ -1,0 +1,49 @@
+# -*- coding: utf-8 -*-
+import time
+
+from sqlitedict import SqliteDict
+
+from scrapy.utils.request import request_fingerprint
+
+
+class CrawlOnceDB:
+    """ DB for requests deduplication.
+
+    A key is a request fingerprint or ``request.meta['crawl_once_key']``
+    (if defined).
+
+    Value is a timestamp by default, or ``request.meta['crawl_once_value']``
+    (if defined).
+    """
+    def __init__(self, path):
+        self.db = SqliteDict(
+            filename=path,
+            tablename='requests',
+            autocommit=True,
+        )
+        self.path = path
+
+    def mark_seen(self, request):
+        key = self._get_key(request)
+        self.db[key] = request.meta.get('crawl_once_value', time.time())
+
+    def is_seen(self, request):
+        key = self._get_key(request)
+        return key in self.db
+
+    def unsee(self, request):
+        key = self._get_key(request)
+        try:
+            del self.db[key]
+        except KeyError:
+            pass
+
+    def _get_key(self, request):
+        return (request.meta.get('crawl_once_key') or
+                request_fingerprint(request))
+
+    def close(self):
+        self.db.close()
+
+    def __len__(self):
+        return len(self.db)

--- a/tests/test_middleware.py
+++ b/tests/test_middleware.py
@@ -39,9 +39,9 @@ def test_db_created(tmpdir):
         'CRAWL_ONCE_PATH': str(tmpdir)
     })
     with opened_middleware(crawler) as mw:
-        assert os.path.isfile(mw.db.filename)
-        assert mw.db.filename.startswith(str(tmpdir))
-    assert os.path.isfile(mw.db.filename)
+        assert os.path.isfile(mw.db.db.filename)
+        assert mw.db.db.filename.startswith(str(tmpdir))
+    assert os.path.isfile(mw.db.db.filename)
 
 
 def test_crawl(tmpdir):


### PR DESCRIPTION
TODO:

* [x] DB object
* [ ] allow to inject DB to callbacks
* [ ] tests
* [x] docs
* [ ] check if old Pythons need to be dropped