### PR TITLE
add CRAWL_ONCE_RESET setting

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -71,6 +71,8 @@ Settings
   (False by default). When True, all requests are handled by
   this middleware unless disabled explicitly using
   ``request.meta['crawl_once'] = False``.
+* ``CRAWL_ONCE_RESET`` - reset the state, clearing out all seen requests
+Default is False.
 
 Alternatives
 ------------


### PR DESCRIPTION
Aimed to fix #4 
Added setting similar to DELTAFETCH_RESET

Expected usage:
in settings.py: 
`CRAWL_ONCE_RESET = True`
or in terminal:
`scrapy crawl spider_name -a crawl_once_reset=True`

If True, 
`SqliteDict.clear()` is called on the db
